### PR TITLE
Handle kernel configuration automatically

### DIFF
--- a/docs/src/manual/gpu.md
+++ b/docs/src/manual/gpu.md
@@ -133,6 +133,11 @@ mul!(yg, Dg, ug)                           # auto-tuned
 mul!(yg, Dg, ug; nthreads = 128)           # explicit block size
 ```
 
+The result of the auto-tuned `mul!` is stored for any remaining calls to `mul!`
+with the same argument types, persistent for the lifetime of the Julia session.
+To reset this cached result, call `FDGrids.reset_launch_params()`, which will
+prompt `mul!` to perform auto-tuning the next time it is called.
+
 The result of the multiplication does not depend on the block size, only the
 runtime.
 

--- a/ext/FDGridsCUDAExt.jl
+++ b/ext/FDGridsCUDAExt.jl
@@ -151,6 +151,40 @@ end
 
 
 # ================================================================================
+# Launch configuration settings
+# ================================================================================
+const LAUNCH_PARAMS = Dict{Tuple{Type, NTuple}, Int32}()
+
+"""
+    _get_launch_params(kernel_f, kernel_args...) -> Int32
+
+Get the tuned threads, obtained via @cuda launch configuration, for
+the specific GPU kernel function `kernel_f` and kernel arguments
+`kernel_args`.
+
+If a configuration has already been performed for
+the kernel and arguments provided then the result is just fetched
+from the `LAUNCH_PARAMS` variable.
+"""
+function _get_launch_params(kernel_f::F, kernel_args...) where {F}
+    key = (F, map(typeof, kernel_args))
+    get!(LAUNCH_PARAMS, key) do
+        kernel = @cuda launch=false kernel_f(kernel_args...)
+        Int32(CUDA.launch_configuration(kernel.fun).threads)
+    end
+end
+
+"""
+    reset_launch_params!()
+
+Clear the `LAUNCH_PARAMS` variable. Useful when benchmarking different
+methods explicitly, or after moving to a different GPU with different
+performance characteristics.
+"""
+FDGrids.reset_launch_params!() = empty!(LAUNCH_PARAMS)
+
+
+# ================================================================================
 # GPU kernel helpers
 # ================================================================================
 #
@@ -434,69 +468,6 @@ descriptive message if either condition is violated.
     return nothing
 end
 
-"""
-    _launch_config(kernel, total, nthreads) -> (threads, blocks)
-
-Decide how many threads-per-block and how many blocks to use for a kernel.
-
-When `nthreads` is `nothing`, the per-block thread count is taken from
-`launch_configuration` (occupancy heuristic) and capped at `total` for very
-small launches. When `nthreads` is supplied, the caller's choice is honored
-verbatim — useful for benchmarks pinning a block size.
-
-`blocks` is computed by ceiling division of `total` by the chosen thread
-count, so the launch covers all `total` outputs while leaving a possibly
-under-filled final block.
-"""
-@inline function _launch_config(kernel, total::Int, nthreads)
-    config  = launch_configuration(kernel.fun)
-    threads = isnothing(nthreads) ? min(config.threads, total) : nthreads
-    blocks  = cld(total, threads)
-    return threads, blocks
-end
-
-"""
-    optimal_forward_threads(y, A::DiffMatrix, x, ::Val{DIM}; max_threads=nothing)
-
-Determine the optimal number of threads required to run the
-[`_gpu_forward_kernel`](@ref).
-
-Run this function and store the results for later use when calling [`mul!`](@ref)
-with GPU data.
-"""
-function FDGrids.optimal_forward_threads(y::AbstractArray,
-                                         A::DiffMatrix{T, WIDTH},
-                                         x::AbstractArray,
-                                          ::Val{DIM};
-                               max_threads=nothing) where {T, WIDTH, DIM}
-    k = @cuda launch=false _gpu_forward_kernel!(
-        y, A.coeffs, x, Int32.(size(x)), Val(Int32(DIM)), Val(Int32(WIDTH))
-    )
-    threads = launch_configuration(k.fun).threads
-    return isnothing(max_threads) ? threads : min(threads, max_threads)
-end
-
-"""
-    optimal_adjoint_threads(y, A::DiffMatrix, x, ::Val{DIM}; max_threads=nothing)
-
-Determine the optimal number of threads required to run the
-[`_gpu_adjoint_kernel`](@ref).
-
-Run this function and store the results for later use when calling [`mul!`](@ref)
-with GPU data.
-"""
-function FDGrids.optimal_adjoint_threads(y::AbstractArray,
-                                         A::AdjointDiffMatrix{T, WIDTH},
-                                         x::AbstractArray,
-                                          ::Val{DIM};
-                               max_threads=nothing) where {T, WIDTH, DIM}
-    k = @cuda launch=false _gpu_adjoint_kernel!(
-        y, A.coeffs, x, Int32.(size(x)), Val(Int32(DIM)), Val(Int32(WIDTH))
-    )
-    threads = launch_configuration(k.fun).threads
-    return isnothing(max_threads) ? threads : min(threads, max_threads)
-end
-
 
 # ================================================================================
 # Public mul! dispatch
@@ -556,18 +527,15 @@ function LinearAlgebra.mul!(y::AbstractArray{S, N},
     sz     = Int32.(size(x))
     total  = length(x)
 
-    if TH <: Nothing
-        kernel = @cuda launch=false _gpu_forward_kernel!(
-            y, A.coeffs, x, sz, Val(Int32(DIM)), Val(Int32(WIDTH)))
-
-        threads, blocks = _launch_config(kernel, total, nthreads)
-        kernel(y, A.coeffs, x, sz, Val(Int32(DIM)), Val(Int32(WIDTH));
-            threads, blocks)
+    # kernel configuration
+    kernel_args = (y, A.coeffs, x, sz, Val(Int32(DIM)), Val(Int32(WIDTH)))
+    _nthreads = if TH <: Nothing
+        _get_launch_params(_gpu_forward_kernel!, kernel_args...)
     else
-        @cuda threads=nthreads blocks=cld(total, nthreads) _gpu_forward_kernel!(
-            y, A.coeffs, x, sz, Val(Int32(DIM)), Val(Int32(WIDTH))
-        )
+        Int32(nthreads)
     end
+
+    @cuda threads=_nthreads blocks=Int32(cld(total, _nthreads)) _gpu_forward_kernel!(kernel_args...)
 
     return y
 end
@@ -615,27 +583,28 @@ function LinearAlgebra.mul!(y::AbstractArray{S, N},
                              ::Val{DIM} =Val(1);
                             nthreads::TH=nothing
                             ) where {T, S, N, WIDTH, P, DIM, TH<:Union{Nothing, Int}}
+    # Rank cap of 4 reflects the rank cap of the CPU code path and keeps the
+    # generated kernel compilation footprint bounded. Most callers use N ≤ 3.
     N   in 1:4 || throw(ArgumentError("N must be in 1:4"))
     DIM in 1:N || throw(ArgumentError("DIM must be in 1:N"))
     size(A, 1) > 2 * WIDTH ||
         throw(ArgumentError("GPU adjoint requires size(A,1) > 2*WIDTH"))
     _check_shapes(y, A, x, Val(DIM))
 
+    # `sz` is passed as a kernel argument so the device kernel can decompose
+    # the flat thread id into N-D indices without a dynamic shape query.
     sz     = Int32.(size(x))
     total  = length(x)
 
-    if TH <: Nothing
-        kernel = @cuda launch=false _gpu_adjoint_kernel!(
-            y, A.coeffs, x, sz, Val(Int32(DIM)), Val(Int32(WIDTH)))
-
-        threads, blocks = _launch_config(kernel, total, nthreads)
-        kernel(y, A.coeffs, x, sz, Val(Int32(DIM)), Val(Int32(WIDTH));
-            threads, blocks)
+    # kernel configuration
+    kernel_args = (y, A.coeffs, x, sz, Val(Int32(DIM)), Val(Int32(WIDTH)))
+    _nthreads = if TH <: Nothing
+        _get_launch_params(_gpu_adjoint_kernel!, kernel_args...)
     else
-        @cuda threads=nthreads blocks=cld(total, nthreads) _gpu_adjoint_kernel!(
-            y, A.coeffs, x, sz, Val(Int32(DIM)), Val(Int32(WIDTH))
-        )
+        Int32(nthreads)
     end
+
+    @cuda threads=_nthreads blocks=Int32(cld(total, _nthreads)) _gpu_adjoint_kernel!(kernel_args...)
 
     return y
 end

--- a/src/FDGrids.jl
+++ b/src/FDGrids.jl
@@ -36,8 +36,6 @@ export DiffMatrix,
        EvenSymmetry,
        OddSymmetry
 
-# required dummy definitions to make extension methods available
-function optimal_forward_threads end
-function optimal_adjoint_threads end
+function reset_launch_params! end
 
 end

--- a/test/FDGridsCUDAExt/test_gpu.jl
+++ b/test/FDGridsCUDAExt/test_gpu.jl
@@ -41,7 +41,7 @@ end
 @testset "FDGridsCUDAExt: adaptation                     " begin
     M = 64
     @testset "DiffMatrix width=$width" for width in (3, 5, 7)
-        xs = collect(range(-1.0, 1.0; length = M))
+        xs = collect(range(-1.0, 1.0; length=M))
         D  = DiffMatrix(xs, width, 1)
 
         # cu downcasts to Float32 and produces CuArray storage
@@ -60,7 +60,7 @@ end
     end
 
     @testset "AdjointDiffMatrix width=$width" for width in (3, 5, 7)
-        xs  = collect(range(-1.0, 1.0; length = M))
+        xs  = collect(range(-1.0, 1.0; length=M))
         D   = DiffMatrix(xs, width, 1)
         At  = adjoint(D)
 
@@ -83,7 +83,7 @@ end
     end
 
     @testset "weighted AdjointDiffMatrix width=$width" for width in (3, 5, 7)
-        xs = collect(range(-1.0, 1.0; length = M))
+        xs = collect(range(-1.0, 1.0; length=M))
         D  = DiffMatrix(xs, width, 1)
         w  = 1.0 .+ rand(M)
         Aw = adjoint(D, w)
@@ -104,7 +104,7 @@ end
     @testset "T=$T width=$width" for T in (Float32, Float64), width in (3, 5, 7)
         rtol = T === Float32 ? _GPU_RTOL_F32 : _GPU_RTOL_F64
 
-        xs = collect(range(-1.0, 1.0; length = M))
+        xs = collect(range(-1.0, 1.0; length=M))
         D  = DiffMatrix(xs, width, 1)
         Dg = _gpu_op(D, T)
 
@@ -131,7 +131,7 @@ end
             width in (3, 5, 7)
 
         rtol  = T === Float32 ? _GPU_RTOL_F32 : _GPU_RTOL_F64
-        xs    = collect(range(-1.0, 1.0; length = M))
+        xs    = collect(range(-1.0, 1.0; length=M))
         D     = DiffMatrix(xs, width, 1)
         Dg    = _gpu_op(D, T)
         shape = ntuple(d -> d == DIM ? M : OTHER, N)
@@ -158,7 +158,7 @@ end
     @testset "T=$T width=$width" for T in (Float32, Float64), width in (3, 5, 7)
         rtol = T === Float32 ? _GPU_RTOL_F32 : _GPU_RTOL_F64
 
-        xs = collect(range(-1.0, 1.0; length = M))
+        xs = collect(range(-1.0, 1.0; length=M))
         D  = DiffMatrix(xs, width, 1)
         At = adjoint(D)
         Ag = _gpu_op(At, T)
@@ -188,7 +188,7 @@ end
         # adjoint requires M > 2*WIDTH for a non-empty body
         M > 2 * width || continue
         rtol  = T === Float32 ? _GPU_RTOL_F32 : _GPU_RTOL_F64
-        xs    = collect(range(-1.0, 1.0; length = M))
+        xs    = collect(range(-1.0, 1.0; length=M))
         D     = DiffMatrix(xs, width, 1)
         At    = adjoint(D)
         Ag    = _gpu_op(At, T)
@@ -221,7 +221,7 @@ end
     @testset "T=$T width=$width" for T in (Float32, Float64), width in (3, 5, 7)
         rtol = T === Float32 ? _GPU_RTOL_F32 : _GPU_RTOL_F64
 
-        xs = collect(range(-1.0, 1.0; length = M))
+        xs = collect(range(-1.0, 1.0; length=M))
         D  = DiffMatrix(xs, width, 1)
         w  = 1.0 .+ rand(M)
         Aw = adjoint(D, w)
@@ -245,7 +245,7 @@ end
 # ================================================================================
 @testset "FDGridsCUDAExt: argument validation            " begin
     M  = 32
-    xs = collect(range(-1.0, 1.0; length = M))
+    xs = collect(range(-1.0, 1.0; length=M))
     D  = DiffMatrix(xs, 5, 1)
     Dg = cu(D)
 
@@ -280,7 +280,7 @@ end
 # ================================================================================
 @testset "FDGridsCUDAExt: nthreads override              " begin
     M  = 256
-    xs = collect(range(-1.0, 1.0; length = M))
+    xs = collect(range(-1.0, 1.0; length=M))
     D  = DiffMatrix(xs, 5, 1)
     Dg = cu(D)
     At = adjoint(D)
@@ -288,20 +288,17 @@ end
 
     u  = sin.(xs)
     ug = CuArray(Float32.(u))
-
     yg_auto = similar(ug)
     yg_pin  = similar(ug)
-    nthreads_forward = FDGrids.optimal_forward_threads(yg_pin, Dg, ug, Val(1))
-    nthreads_adjoint = FDGrids.optimal_adjoint_threads(yg_pin, Ag, ug, Val(1))
 
     # The result must not depend on the per-block thread count, so a small
     # custom block size should still produce the same field as the auto-tuned
     # default. 32 ensures at least one warp per block.
     mul!(yg_auto, Dg, ug)
-    mul!(yg_pin,  Dg, ug; nthreads=nthreads_forward)
+    mul!(yg_pin,  Dg, ug; nthreads=64)
     @test Array(yg_auto) ≈ Array(yg_pin)
 
     mul!(yg_auto, Ag, ug)
-    mul!(yg_pin,  Ag, ug; nthreads=nthreads_adjoint)
+    mul!(yg_pin,  Ag, ug; nthreads=64)
     @test Array(yg_auto) ≈ Array(yg_pin)
 end


### PR DESCRIPTION
Refactored kernel configuration to avoid explicit method calls `optimal_forward_threads` and `optimal_adjoint_threads`. Optimal threads from launch configuration is now stored in `LAUNCH_PARAMS` variable that can be accessed by `mul!` methods. This means the optimal threads are generated once for the given input types to `mul!` and kept for later computations without any extra work by the user.